### PR TITLE
Remove support for query in show since it breaks compatibility with

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -33,8 +33,7 @@ exports.index = function(req, res, next) {
 };
 
 exports.show = function(req, res, next) {
-  extend(req.query, { where: { id: req.params.id } });
-  this.find(req.query, function(err, model) {
+  this.find(req.params.id, function(err, model) {
     if (err) return next(err);
     res.json(model);
   });


### PR DESCRIPTION
other dbs.

I added a comment about this, but I think is better to create a pull request.

I saw that you added support for queries for the show action, but this breaks compatibility with query languages because it assumes that queries are done in the way of:

``` js
{ where: { ... } }
```

which for instance breaks the modella/mongo plugin.

This action should stay as it was originally in order to be compatible.
